### PR TITLE
Add language specific querying

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,12 +3,16 @@
 ## 0.x.x
 
 TBD
+## 0.3.3 ( 2017-12-06 )
+-----------
+### Improved
+-PR #61: Adding --lang functionality which can retrieve tweets written in a specific language. 
+
 
 ## 0.3.2 ( 2017-11-12 )
 -----------
 ### Improved
 -PR #55: Adding --dump functionality which dumps the scraped tweets to screen, instead of an outputfile.
-
 
 
 ## 0.3.1 ( 2017-11-05 )

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ You can use the command line application to get your tweets stored to JSON
 right away. 
 Twitterscraper takes several arguments:
 
+- `-h` or `--help`
+Print out the help message and exits.
+
 - `-l` or `--limit`
 TwitterScraper stops scraping when *at least* the number of tweets indicated with `--limit` is scraped. 
 Since tweets are retrieved in batches of 20, this will always be a multiple of 20. 
@@ -63,6 +66,9 @@ Since tweets are retrieved in batches of 20, this will always be a multiple of 2
     Omit the limit to retrieve all tweets. You can at any time abort the scraping
 by pressing Ctrl+C, the scraped tweets will be stored safely in your JSON file.
   
+- `--lang`
+Retrieves tweets written in a specific language. Currently 30+ languages are supported. For a full list of the languages print out the help message.
+
 - `-o` or `--output`
 Gives the name of the output file. If no output filename is given, the default filename 'tweets.json' will be used. 
 

--- a/README.rst
+++ b/README.rst
@@ -55,22 +55,30 @@ or you can clone the repository and in the folder containing setup.py
 You can use the command line application to get your tweets stored to
 JSON right away. Twitterscraper takes several arguments:
 
+-  ``-h`` or ``--help`` Print out the help message and exits.
+
 -  ``-l`` or ``--limit`` TwitterScraper stops scraping when *at least*
    the number of tweets indicated with ``--limit`` is scraped. Since
    tweets are retrieved in batches of 20, this will always be a multiple
    of 20.
 
-Omit the limit to retrieve all tweets. You can at any time abort the
-scraping by pressing Ctrl+C, the scraped tweets will be stored safely in
-your JSON file.
+   Omit the limit to retrieve all tweets. You can at any time abort the
+   scraping by pressing Ctrl+C, the scraped tweets will be stored safely
+   in your JSON file.
+
+-  ``--lang`` Retrieves tweets written in a specific language. Currently
+   30+ languages are supported. For a full list of the languages print
+   out the help message.
 
 -  ``-o`` or ``--output`` Gives the name of the output file. If no
-   outputfilename is given, the default filename 'tweets.json' will be
+   output filename is given, the default filename 'tweets.json' will be
    used.
 
 -  ``-d`` or ``--dump``: With this argument, the scraped tweets will be
    printed to the screen instead of an outputfile. If you are using this
    argument, the ``--output`` argument doe not need to be used.
+
+Below is an example of how twitterscraper can be used:
 
 ``twitterscraper Trump --limit 100 --output=tweets.json``
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,12 +3,16 @@
 ## 0.x.x
 
 TBD
+## 0.3.3 ( 2017-12-06 )
+-----------
+### Improved
+-PR #61: Adding --lang functionality which can retrieve tweets written in a specific language. 
+
 
 ## 0.3.2 ( 2017-11-12 )
 -----------
 ### Improved
 -PR #55: Adding --dump functionality which dumps the scraped tweets to screen, instead of an outputfile.
-
 
 
 ## 0.3.1 ( 2017-11-05 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as requirements:
 
 setup(
     name='twitterscraper',
-    version='0.3.2',
+    version='0.3.3',
     description='Tool for scraping Tweets',
     url='https://github.com/taspinar/twitterscraper',
     author=['Ahmet Taspinar', 'Lasse Schuirmann'],

--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -3,7 +3,7 @@ This is a command line application that allows you to scrape twitter!
 """
 import collections
 import json
-from argparse import ArgumentParser
+import argparse
 from datetime import datetime
 from os.path import isfile
 from json import dump
@@ -37,7 +37,7 @@ class JSONEncoder(json.JSONEncoder):
 def main():
     logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
     try:
-        parser = ArgumentParser(
+        parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
             description=__doc__
         )
 
@@ -54,12 +54,28 @@ def main():
                                  "gathering. The number of tweets however, "
                                  "will be capped at around 100000 per 10 "
                                  "days.")
-        parser.add_argument("-d", "--dump", action='store_true',
-                            help="Set this flag if you want to dump the tweets "
-                                 "to the console rather than outputting to a file")
+        parser.add_argument("--lang", type=str, default=None,
+                            help="Set this flag if you want to query tweets in \na specific language. You can choose from:\n"
+                                 " en (English)\n ar (Arabic)\n bn (Bengali)\n"
+                                 " cs (Czech)\n da (Danish)\n de (German)\n el (Greek)\n es (Spanish)\n"
+                                 " fa (Persian)\n fi (Finnish)\n fil (Filipino)\n fr (French)\n"
+                                 " he (Hebrew)\n hi (Hindi)\n hu (Hungarian)\n"
+                                 " id (Indonesian)\n it (Italian)\n ja (Japanese)\n"
+                                 " ko (Korean)\n msa (Malay)\n nl (Dutch)\n"
+                                 " no (Norwegian)\n pl (Polish)\n pt (Portuguese)\n"
+                                 " ro (Romanian)\n ru (Russian)\n sv (Swedish)\n"
+                                 " th (Thai)\n tr (Turkish)\n uk (Ukranian)\n"
+                                 " ur (Urdu)\n vi (Vietnamese)\n"
+                                 " zh-cn (Chinese Simplified)\n"
+                                 " zh-tw (Chinese Traditional)"
+                                 )
+        parser.add_argument("-d", "--dump", action="store_true", 
+                            help="Set this flag if you want to dump the tweets \nto the console rather than outputting to a file")
         args = parser.parse_args()
 
-
+        if args.lang:
+            args.query = "{}&l={}".format(args.query, args.lang)
+        
         if args.all:
             tweets = query_all_tweets(args.query)
         else:

--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -73,6 +73,10 @@ def main():
                             help="Set this flag if you want to dump the tweets \nto the console rather than outputting to a file")
         args = parser.parse_args()
 
+        if isfile(args.output) and not args.dump:
+            logging.error("Output file already exists! Aborting.")
+            exit(-1)
+        
         if args.lang:
             args.query = "{}&l={}".format(args.query, args.lang)
         
@@ -83,11 +87,7 @@ def main():
 
         if args.dump:
             print(json.dumps(tweets, cls=JSONEncoder))
-
         else: #if not using --dump
-            if isfile(args.output):
-                logging.error("Output file already exists! Aborting.")
-                exit(-1)
             with open(args.output, "w") as output:
                 dump(tweets, output, cls=JSONEncoder)
     except KeyboardInterrupt:

--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -56,18 +56,18 @@ def main():
                                  "days.")
         parser.add_argument("--lang", type=str, default=None,
                             help="Set this flag if you want to query tweets in \na specific language. You can choose from:\n"
-                                 " en (English)\n ar (Arabic)\n bn (Bengali)\n"
-                                 " cs (Czech)\n da (Danish)\n de (German)\n el (Greek)\n es (Spanish)\n"
-                                 " fa (Persian)\n fi (Finnish)\n fil (Filipino)\n fr (French)\n"
-                                 " he (Hebrew)\n hi (Hindi)\n hu (Hungarian)\n"
-                                 " id (Indonesian)\n it (Italian)\n ja (Japanese)\n"
-                                 " ko (Korean)\n msa (Malay)\n nl (Dutch)\n"
-                                 " no (Norwegian)\n pl (Polish)\n pt (Portuguese)\n"
-                                 " ro (Romanian)\n ru (Russian)\n sv (Swedish)\n"
-                                 " th (Thai)\n tr (Turkish)\n uk (Ukranian)\n"
-                                 " ur (Urdu)\n vi (Vietnamese)\n"
-                                 " zh-cn (Chinese Simplified)\n"
-                                 " zh-tw (Chinese Traditional)"
+                                 "en (English)\nar (Arabic)\nbn (Bengali)\n"
+                                 "cs (Czech)\nda (Danish)\nde (German)\nel (Greek)\nes (Spanish)\n"
+                                 "fa (Persian)\nfi (Finnish)\nfil (Filipino)\nfr (French)\n"
+                                 "he (Hebrew)\nhi (Hindi)\nhu (Hungarian)\n"
+                                 "id (Indonesian)\nit (Italian)\nja (Japanese)\n"
+                                 "ko (Korean)\nmsa (Malay)\nnl (Dutch)\n"
+                                 "no (Norwegian)\npl (Polish)\npt (Portuguese)\n"
+                                 "ro (Romanian)\nru (Russian)\nsv (Swedish)\n"
+                                 "th (Thai)\ntr (Turkish)\nuk (Ukranian)\n"
+                                 "ur (Urdu)\nvi (Vietnamese)\n"
+                                 "zh-cn (Chinese Simplified)\n"
+                                 "zh-tw (Chinese Traditional)"
                                  )
         parser.add_argument("-d", "--dump", action="store_true", 
                             help="Set this flag if you want to dump the tweets \nto the console rather than outputting to a file")


### PR DESCRIPTION
Twitter has added the query parameter "l=<LANG>" to the url to retrieve tweets in a specific language. 

Using this works better than adding " lang:<LANG>" to the keyword parameter. 