### PR TITLE
Refactoring pooling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,27 @@
 ## 0.x.x
 
 TBD
+## 0.4 ( 2017-12-19 )
+-----------
+### Added
+- Added "-bd / --begindate" command line arguments to set the begin date of the query
+- Added "-ed / --enddate" command line arguments to set the end date of the query.
+- Added "-p / --poolsize" command line arguments which can change the number of parallel processes.
+  Default number of parallel processes is set to 20.
+
+### Improved
+- Outputfile is only created if tweets are actually retrieved.
+
+### Removed
+- The ´query_all_tweets' method in the Query module is removed. Since twitterscraper is starting parallel processes by default,
+  this method is no longer necessary.
+
+### Changed
+- The 'query_tweets' method now takes as arguments query, limit, begindate, enddate, poolsize.
+- The 'query_tweets_once' no longer has the argument 'num_tweets'
+- The default value of the 'retry' argument of the 'query_single_page' method has been increased from 3 to 10.
+- The ´query_tweets_once' method does not log to screen at every single scrape, but at the end of a batch.
+
 ## 0.3.3 ( 2017-12-06 )
 -----------
 ### Added

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Below is an example of how twitterscraper can be used:
 
 `twitterscraper Trump -l 100 -o tweets.json`
 
+`twitterscraper Trump -l 100 -bd 2017-01-01 -ed 2017-06-01 -o tweets.json`
+
 
 ## 2.3 From within Python
 You can easily use TwitterScraper from within python:
@@ -123,11 +125,11 @@ so that twitterscraper can recognize it as one single query.
 
 Here are some examples:
 
-+ search for the occurence of 'Bitcoin' or 'BTC': ```twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json```
-+ search for the occurence of 'Bitcoin' and 'BTC': ```twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json```
-+ search for tweets from a specific user: ```twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json```
-+ search for tweets to a specific user: ```twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json```
-+ search for tweets written from a location: ```twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json```
++ search for the occurence of 'Bitcoin' or 'BTC': ```twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json -l 1000```
++ search for the occurence of 'Bitcoin' and 'BTC': ```twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json -l 1000```
++ search for tweets from a specific user: ```twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json -l 1000```
++ search for tweets to a specific user: ```twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json -l 1000```
++ search for tweets written from a location: ```twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json -l 1000```
 
 
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ by pressing Ctrl+C, the scraped tweets will be stored safely in your JSON file.
 - `--lang`
 Retrieves tweets written in a specific language. Currently 30+ languages are supported. For a full list of the languages print out the help message.
 
+- `-bd` or `--begindate`
+Set the date from which TwitterScraper should start scraping for your query. Format is YYYY-MM-DD. The default value is set to 2017-01-01.
+
+- `-ed` or `--enddate`
+Set the enddate which TwitterScraper should use to stop scraping for your query. Format is YYYY-MM-DD. The default value is set to today.
+
+- `-p` or `--poolsize`
+Set the number of parallel processes TwitterScraper should initiate while scraping for your query. Default value is set to 20.
+Depending on the computational power you have, you can increase this number.
+It is advised to keep this number below half of the number of days you are scraping.
+For example, if you are scraping from 2017-01-10 to 2017-01-20, you can set this number to a maximum of 5.
+If you are scraping from 2016-01-01 to 2016-12-31, you can increase this number to a maximum of 150, if you have the computational resources.
+
+
 - `-o` or `--output`
 Gives the name of the output file. If no output filename is given, the default filename 'tweets.json' will be used. 
 
@@ -109,23 +123,23 @@ You can use any advanced query twitter supports. Simply compile your query at
 between q= and the first subsequent &. 
 
 For example, from the URL
-`https://twitter.com/search?l=&q=Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi%20since%3A2017-05-02%20until%3A2017-05-05&src=typd&lang=en`
+`https://twitter.com/search?l=&q=Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi&src=typd&lang=en`
 
 you need to copy the following part:
-`Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi%20since%3A2017-05-02%20until%3A2017-05-05`
+`Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi`
 
 
 
 You can use the CLI with the advanced query, the same way as a simple query:
 
 + based on a daterange: 
-```twitterscraper Trump%20since%3A2017-01-03%20until%3A2017-01-04 -o tweets.json```
+```twitterscraper Trump -bd 2017-01-01 -ed A2017-06-01 -o tweets.json```
 
 + based on a daterange and location: 
-```twitterscraper Trump%20near%3A"Seattle%2C%20WA"%20within%3A15mi%20since%3A2017-05-02%20until%3A2017-05-05 -o tweets.json```
+```twitterscraper "Trump near:Seattle within:15mi" -bd 2017-01-01 -ed 2017-06-01 -o tweets.json```
 
 + based on a specific author: 
-```twitterscraper Trump%20from%3AAlWest13 -o tweets.json```
+```twitterscraper "Trump from:AlWest13" -o tweets.json```
 
 
 

--- a/README.md
+++ b/README.md
@@ -118,28 +118,16 @@ file.close()
 ```
 
 ## 2.4 Composing advanced queries
-You can use any advanced query twitter supports. Simply compile your query at
-<https://twitter.com/search-advanced>. After you compose your advanced search, copy the part of the URL 
-between q= and the first subsequent &. 
+You can use any advanced query Twitter supports. An advanced query should be placed within quotes,
+so that twitterscraper can recognize it as one single query.
 
-For example, from the URL
-`https://twitter.com/search?l=&q=Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi&src=typd&lang=en`
+Here are some examples:
 
-you need to copy the following part:
-`Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi`
-
-
-
-You can use the CLI with the advanced query, the same way as a simple query:
-
-+ based on a daterange: 
-```twitterscraper Trump -bd 2017-01-01 -ed A2017-06-01 -o tweets.json```
-
-+ based on a daterange and location: 
-```twitterscraper "Trump near:Seattle within:15mi" -bd 2017-01-01 -ed 2017-06-01 -o tweets.json```
-
-+ based on a specific author: 
-```twitterscraper "Trump from:AlWest13" -o tweets.json```
++ search for the occurence of 'Bitcoin' or 'BTC': ```twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json```
++ search for the occurence of 'Bitcoin' and 'BTC': ```twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json```
++ search for tweets from a specific user: ```twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json```
++ search for tweets to a specific user: ```twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json```
++ search for tweets written from a location: ```twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json```
 
 
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ With this argument, the scraped tweets will be printed to the screen instead of 
 If you are using this argument, the `--output` argument doe not need to be used. 
 
 
+### 2.2.1 Examples of simple queries
+
 Below is an example of how twitterscraper can be used:
 
 `twitterscraper Trump --limit 100 --output=tweets.json`
@@ -99,6 +101,21 @@ Below is an example of how twitterscraper can be used:
 `twitterscraper Trump -l 100 -o tweets.json`
 
 `twitterscraper Trump -l 100 -bd 2017-01-01 -ed 2017-06-01 -o tweets.json`
+
+
+
+### 2.2.2 Examples of advanced queries
+You can use any advanced query Twitter supports. An advanced query should be placed within quotes,
+so that twitterscraper can recognize it as one single query.
+
+Here are some examples:
+
++ search for the occurence of 'Bitcoin' or 'BTC': ```twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json -l 1000```
++ search for the occurence of 'Bitcoin' and 'BTC': ```twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json -l 1000```
++ search for tweets from a specific user: ```twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json -l 1000```
++ search for tweets to a specific user: ```twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json -l 1000```
++ search for tweets written from a location: ```twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json -l 1000```
+
 
 
 ## 2.3 From within Python
@@ -118,20 +135,6 @@ for tweet in query_tweets("Trump OR Clinton", 10):
 file.close()
 
 ```
-
-## 2.4 Composing advanced queries
-You can use any advanced query Twitter supports. An advanced query should be placed within quotes,
-so that twitterscraper can recognize it as one single query.
-
-Here are some examples:
-
-+ search for the occurence of 'Bitcoin' or 'BTC': ```twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json -l 1000```
-+ search for the occurence of 'Bitcoin' and 'BTC': ```twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json -l 1000```
-+ search for tweets from a specific user: ```twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json -l 1000```
-+ search for tweets to a specific user: ```twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json -l 1000```
-+ search for tweets written from a location: ```twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json -l 1000```
-
-
 
 # 3. Output
 

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,8 @@ Below is an example of how twitterscraper can be used:
 
 ``twitterscraper Trump -l 100 -o tweets.json``
 
+``twitterscraper Trump -l 100 -bd 2017-01-01 -ed 2017-06-01 -o tweets.json``
+
 2.3 From within Python
 ----------------------
 
@@ -132,15 +134,15 @@ as one single query.
 Here are some examples:
 
 -  search for the occurence of 'Bitcoin' or 'BTC':
-   ``twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json``
+   ``twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json -l 1000``
 -  search for the occurence of 'Bitcoin' and 'BTC':
-   ``twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json``
+   ``twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json -l 1000``
 -  search for tweets from a specific user:
-   ``twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json``
+   ``twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json -l 1000``
 -  search for tweets to a specific user:
-   ``twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json``
+   ``twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json -l 1000``
 -  search for tweets written from a location:
-   ``twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json``
+   ``twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json -l 1000``
 
 3. Output
 =========

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,24 @@ JSON right away. Twitterscraper takes several arguments:
    30+ languages are supported. For a full list of the languages print
    out the help message.
 
+-  ``-bd`` or ``--begindate`` Set the date from which TwitterScraper
+   should start scraping for your query. Format is YYYY-MM-DD. The
+   default value is set to 2017-01-01.
+
+-  ``-ed`` or ``--enddate`` Set the enddate which TwitterScraper should
+   use to stop scraping for your query. Format is YYYY-MM-DD. The
+   default value is set to today.
+
+-  ``-p`` or ``--poolsize`` Set the number of parallel processes
+   TwitterScraper should initiate while scraping for your query. Default
+   value is set to 20. Depending on the computational power you have,
+   you can increase this number. It is advised to keep this number below
+   half of the number of days you are scraping. For example, if you are
+   scraping from 2017-01-10 to 2017-01-20, you can set this number to a
+   maximum of 5. If you are scraping from 2016-01-01 to 2016-12-31, you
+   can increase this number to a maximum of 150, if you have the
+   computational resources.
+
 -  ``-o`` or ``--output`` Gives the name of the output file. If no
    output filename is given, the default filename 'tweets.json' will be
    used.
@@ -113,22 +131,22 @@ advanced search, copy the part of the URL between q= and the first
 subsequent &.
 
 For example, from the URL
-``https://twitter.com/search?l=&q=Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi%20since%3A2017-05-02%20until%3A2017-05-05&src=typd&lang=en``
+``https://twitter.com/search?l=&q=Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi&src=typd&lang=en``
 
 you need to copy the following part:
-``Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi%20since%3A2017-05-02%20until%3A2017-05-05``
+``Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi``
 
 You can use the CLI with the advanced query, the same way as a simple
 query:
 
 -  based on a daterange:
-   ``twitterscraper Trump%20since%3A2017-01-03%20until%3A2017-01-04 -o tweets.json``
+   ``twitterscraper Trump -bd 2017-01-01 -ed A2017-06-01 -o tweets.json``
 
 -  based on a daterange and location:
-   ``twitterscraper Trump%20near%3A"Seattle%2C%20WA"%20within%3A15mi%20since%3A2017-05-02%20until%3A2017-05-05 -o tweets.json``
+   ``twitterscraper "Trump near:Seattle within:15mi" -bd 2017-01-01 -ed 2017-06-01 -o tweets.json``
 
 -  based on a specific author:
-   ``twitterscraper Trump%20from%3AAlWest13 -o tweets.json``
+   ``twitterscraper "Trump from:AlWest13" -o tweets.json``
 
 3. Output
 =========

--- a/README.rst
+++ b/README.rst
@@ -125,28 +125,22 @@ You can easily use TwitterScraper from within python:
 2.4 Composing advanced queries
 ------------------------------
 
-You can use any advanced query twitter supports. Simply compile your
-query at https://twitter.com/search-advanced. After you compose your
-advanced search, copy the part of the URL between q= and the first
-subsequent &.
+You can use any advanced query Twitter supports. An advanced query
+should be placed within quotes, so that twitterscraper can recognize it
+as one single query.
 
-For example, from the URL
-``https://twitter.com/search?l=&q=Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi&src=typd&lang=en``
+Here are some examples:
 
-you need to copy the following part:
-``Trump%20near%3A%22Seattle%2C%20WA%22%20within%3A15mi``
-
-You can use the CLI with the advanced query, the same way as a simple
-query:
-
--  based on a daterange:
-   ``twitterscraper Trump -bd 2017-01-01 -ed A2017-06-01 -o tweets.json``
-
--  based on a daterange and location:
-   ``twitterscraper "Trump near:Seattle within:15mi" -bd 2017-01-01 -ed 2017-06-01 -o tweets.json``
-
--  based on a specific author:
-   ``twitterscraper "Trump from:AlWest13" -o tweets.json``
+-  search for the occurence of 'Bitcoin' or 'BTC':
+   ``twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json``
+-  search for the occurence of 'Bitcoin' and 'BTC':
+   ``twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json``
+-  search for tweets from a specific user:
+   ``twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json``
+-  search for tweets to a specific user:
+   ``twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json``
+-  search for tweets written from a location:
+   ``twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json``
 
 3. Output
 =========

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,9 @@ JSON right away. Twitterscraper takes several arguments:
    printed to the screen instead of an outputfile. If you are using this
    argument, the ``--output`` argument doe not need to be used.
 
+2.2.1 Examples of simple queries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Below is an example of how twitterscraper can be used:
 
 ``twitterscraper Trump --limit 100 --output=tweets.json``
@@ -103,6 +106,26 @@ Below is an example of how twitterscraper can be used:
 ``twitterscraper Trump -l 100 -o tweets.json``
 
 ``twitterscraper Trump -l 100 -bd 2017-01-01 -ed 2017-06-01 -o tweets.json``
+
+2.2.2 Examples of advanced queries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use any advanced query Twitter supports. An advanced query
+should be placed within quotes, so that twitterscraper can recognize it
+as one single query.
+
+Here are some examples:
+
+-  search for the occurence of 'Bitcoin' or 'BTC':
+   ``twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json -l 1000``
+-  search for the occurence of 'Bitcoin' and 'BTC':
+   ``twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json -l 1000``
+-  search for tweets from a specific user:
+   ``twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json -l 1000``
+-  search for tweets to a specific user:
+   ``twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json -l 1000``
+-  search for tweets written from a location:
+   ``twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json -l 1000``
 
 2.3 From within Python
 ----------------------
@@ -123,26 +146,6 @@ You can easily use TwitterScraper from within python:
     for tweet in query_tweets("Trump OR Clinton", 10):
         file.write(tweet.encode('utf-8')) 
     file.close()
-
-2.4 Composing advanced queries
-------------------------------
-
-You can use any advanced query Twitter supports. An advanced query
-should be placed within quotes, so that twitterscraper can recognize it
-as one single query.
-
-Here are some examples:
-
--  search for the occurence of 'Bitcoin' or 'BTC':
-   ``twitterscraper "Bitcoin OR BTC " -o bitcoin_tweets.json -l 1000``
--  search for the occurence of 'Bitcoin' and 'BTC':
-   ``twitterscraper "Bitcoin AND BTC " -o bitcoin_tweets.json -l 1000``
--  search for tweets from a specific user:
-   ``twitterscraper "Blockchain from:VitalikButerin" -o blockchain_tweets.json -l 1000``
--  search for tweets to a specific user:
-   ``twitterscraper "Blockchain to:VitalikButerin" -o blockchain_tweets.json -l 1000``
--  search for tweets written from a location:
-   ``twitterscraper "Blockchain near:Seattle within:15mi" -o blockchain_tweets.json -l 1000``
 
 3. Output
 =========

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,28 @@
 ## 0.x.x
 
 TBD
+## 0.4 ( 2017-12-19 )
+-----------
+### Added
+- Added "-bd / --begindate" command line arguments to set the begin date of the query
+- Added "-ed / --enddate" command line arguments to set the end date of the query.
+- Added "-p / --poolsize" command line arguments which can change the number of parallel processes.
+  Default number of parallel processes is set to 20.
+
+### Improved
+- Outputfile is only created if tweets are actually retrieved.
+
+### Removed
+- The ´query_all_tweets' method in the Query module is removed. Since twitterscraper is starting parallel processes by default,
+  this method is no longer necessary.
+
+### Changed
+- The 'query_tweets' method now takes as arguments query, limit, begindate, enddate, poolsize.
+- The 'query_tweets_once' no longer has the argument 'num_tweets'
+- The default value of the 'retry' argument of the 'query_single_page' method has been increased from 3 to 10.
+- The ´query_tweets_once' method does not log to screen at every single scrape, but at the end of a batch.
+
+
 ## 0.3.3 ( 2017-12-06 )
 -----------
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as requirements:
 
 setup(
     name='twitterscraper',
-    version='0.3.3',
+    version='0.4',
     description='Tool for scraping Tweets',
     url='https://github.com/taspinar/twitterscraper',
     author=['Ahmet Taspinar', 'Lasse Schuirmann'],

--- a/twitterscraper/__init__.py
+++ b/twitterscraper/__init__.py
@@ -1,11 +1,11 @@
 # TwitterScraper
-# Copyright 2016-2017 Ahmet Taspinar
+# Copyright 2016-2018 Ahmet Taspinar
 # See LICENSE for details.
 """
 Twitter Scraper tool
 """
 
-__version__ = '0.1'
+__version__ = '0.4'
 __author__ = 'Ahmet Taspinar'
 __license__ = 'MIT'
 

--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -1,27 +1,21 @@
 """
 This is a command line application that allows you to scrape twitter!
 """
-import collections
 import json
-import argparse
-from datetime import datetime
-from os.path import isfile
-from json import dump
-from json import dumps
 import logging
-
-from twitterscraper import query_tweets
-from twitterscraper.query import query_all_tweets
-
+import argparse
+import collections
+import datetime as dt
+from os.path import isfile
+from twitterscraper.query import query_tweets
 
 class JSONEncoder(json.JSONEncoder):
-
     def default(self, obj):
         if hasattr(obj, '__json__'):
             return obj.__json__()
         elif isinstance(obj, collections.Iterable):
             return list(obj)
-        elif isinstance(obj, datetime):
+        elif isinstance(obj, dt.datetime):
             return obj.isoformat()
         elif hasattr(obj, '__getitem__') and hasattr(obj, 'keys'):
             return dict(obj)
@@ -33,6 +27,12 @@ class JSONEncoder(json.JSONEncoder):
 
         return json.JSONEncoder.default(self, obj)
 
+def valid_date(s):
+    try:
+        return dt.datetime.strptime(s, "%Y-%m-%d").date()
+    except ValueError:
+        msg = "Not a valid date: '{0}'.".format(s)
+        raise argparse.ArgumentTypeError(msg)
 
 def main():
     logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
@@ -49,11 +49,9 @@ def main():
                             help="Number of minimum tweets to gather.")
         parser.add_argument("-a", "--all", action='store_true',
                             help="Set this flag if you want to get all tweets "
-                                 "in the history of twitter. This may take a "
-                                 "while but also activates parallel tweet "
-                                 "gathering. The number of tweets however, "
-                                 "will be capped at around 100000 per 10 "
-                                 "days.")
+                                 "in the history of twitter. Begindate is set to 2006-03-01."
+                                 "This may take a while. You can increase the number of parallel"
+                                 "processes depending on the computational power you have.")
         parser.add_argument("--lang", type=str, default=None,
                             help="Set this flag if you want to query tweets in \na specific language. You can choose from:\n"
                                  "en (English)\nar (Arabic)\nbn (Bengali)\n"
@@ -71,6 +69,13 @@ def main():
                                  )
         parser.add_argument("-d", "--dump", action="store_true", 
                             help="Set this flag if you want to dump the tweets \nto the console rather than outputting to a file")
+        parser.add_argument("-bd", "--begindate", type=valid_date, default="2017-01-01",
+                            help="Scrape for tweets starting from this date. Format YYYY-MM-DD. \nDefault value is 2017-01-01", metavar='\b')
+        parser.add_argument("-ed", "--enddate", type=valid_date, default=dt.date.today(),
+                            help="Scrape for tweets until this date. Format YYYY-MM-DD. \nDefault value is the date of today.", metavar='\b')
+        parser.add_argument("-p", "--poolsize", type=int, default=20, help="Specify the number of parallel process you want to run. \n"
+                            "Default value is set to 20. \nYou can change this number if you have more computing power available. \n"
+                            "Set to 1 if you dont want to run any parallel processes.", metavar='\b')
         args = parser.parse_args()
 
         if isfile(args.output) and not args.dump:
@@ -81,14 +86,15 @@ def main():
             args.query = "{}&l={}".format(args.query, args.lang)
         
         if args.all:
-            tweets = query_all_tweets(args.query)
-        else:
-            tweets = query_tweets(args.query, args.limit)
+            args.begindate = dt.date(2006,3,1)
+
+        tweets = query_tweets(args.query, args.limit, args.begindate, args.enddate, args.poolsize)
 
         if args.dump:
             print(json.dumps(tweets, cls=JSONEncoder))
-        else: #if not using --dump
-            with open(args.output, "w") as output:
-                dump(tweets, output, cls=JSONEncoder)
+        else:
+            if tweets:
+                with open(args.output, "w") as output:
+                    json.dump(tweets, output, cls=JSONEncoder)
     except KeyboardInterrupt:
         logging.info("Program interrupted by user. Quitting...")


### PR DESCRIPTION
The biggest change is that the 'query_all_tweets' method is removed from the Query module and the 'query_tweets' method starts 20 parallel processes by default. 

Before, the 'query_all_tweets' method was used to scrape for 'all' tweets on twitter, i.e. from march 2006 until the current date. To increase the speed of such a large search, 20 parallel processes were started. Each process was scraping for a range of 10 days. 

There is no need for a seperate method just to initiate parallel processes and it doesnt make sense to only start parallel processes when the begindate is set to march 2006. Depending on the keyword, the daterange 2017-2018 could contain more tweets than the daterange 2006-2018. 

By default, the poolsize is set to 20. The poolsize can be changed with a command line argument.
To divide the daterange in equal parts, the number of days between the end and begin date is divided by the poolsize and queries are formed accordingly. 

If a limit to the number of tweets is gives, this is also divided by the poolsize, so that each process retrieves the same number of tweets (limit / poolsize).

Since we are now always starting parallel processes, logging is not done after each individual scrape, but after the completion of one parallel process. 

To keep the interface the same, the '-a' command line argument is still being used, but now instead of calling the query_all_tweets method, it sets the begindate to march 2006. 