### PR TITLE
Jsondecodeerror fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,15 @@
 ## 0.x.x
 
 TBD
+## 0.6.2 ( 2018-03-21 )
+### Fixed
+- Errors occuring during the serialization of a non-html response (everything after 1st request), 
+  No longer crashes the program but is catched with a try / except. 
+- Fixes https://github.com/taspinar/twitterscraper/issues/93
+
+- The '@' character in an username is now removed by the ".strip('\@')" method instead of "[1:]". 
+- This fixes issue https://github.com/taspinar/twitterscraper/issues/105  
+
 ## 0.6.1 ( 2018-03-17 )
 ### Improved
 - The way the number of days are divided over the number of parallel processes is improved.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as requirements:
 
 setup(
     name='twitterscraper',
-    version='0.6.1',
+    version='0.6.2',
     description='Tool for scraping Tweets',
     url='https://github.com/taspinar/twitterscraper',
     author=['Ahmet Taspinar', 'Lasse Schuirmann'],

--- a/twitterscraper/query.py
+++ b/twitterscraper/query.py
@@ -33,10 +33,14 @@ def query_single_page(url, html_response=True, retry=10):
     try:
         response = requests.get(url, headers=headers)
         if html_response:
-            html = response.text
+            html = response.text or ''
         else:
-            json_resp = response.json()
-            html = json_resp['items_html']
+            html = ''
+            try:
+                json_resp = json.loads(response.text)
+                html = json_resp['items_html'] or ''
+            except ValueError as e:
+                logging.exception('Failed to parse JSON "{}" while requesting "{}"'.format(e, url))  
 
         tweets = list(Tweet.from_html(html))
 

--- a/twitterscraper/tweet.py
+++ b/twitterscraper/tweet.py
@@ -7,7 +7,7 @@ from coala_utils.decorators import generate_ordering
 @generate_ordering('timestamp', 'id', 'text', 'user', 'replies', 'retweets', 'likes')
 class Tweet:
     def __init__(self, user, fullname, id, url, timestamp, text, replies, retweets, likes, html):
-        self.user = user
+        self.user = user.strip('\@')
         self.fullname = fullname
         self.id = id
         self.url = url
@@ -21,10 +21,10 @@ class Tweet:
     @classmethod
     def from_soup(cls, tweet):
         return cls(
-            user=tweet.find('span', 'username').text[1:],
-            fullname=tweet.find('strong', 'fullname').text,
-            id=tweet['data-item-id'],
-            url = tweet.find('div', 'tweet')['data-permalink-path'],
+            user=tweet.find('span', 'username').text or "",
+            fullname=tweet.find('strong', 'fullname').text or "", 
+            id=tweet['data-item-id'] or "",
+            url = tweet.find('div', 'tweet')['data-permalink-path'] or "",
             timestamp=datetime.utcfromtimestamp(
                 int(tweet.find('span', '_timestamp')['data-time'])),
             text=tweet.find('p', 'tweet-text').text or "",


### PR DESCRIPTION
@jeyoon @sils @eimis41 @tredmill
My excuses for abruptly closing the [other](https://github.com/taspinar/twitterscraper/pull/96#issuecomment-373968942) branch. The logic I had implemented there was flawed, i.e. a response with a status code of 200 does not necessarily have to have to correct JSON-contents. It can also be a 404-page with a html content, leading to a JSONDecodeError when trying to serialize it. 
The best way is to keep the old logic and catch JSONDecodeErrors with a try / except. 