### PR TITLE
fixed bug in query.py that kept queries in an endless loop

### DIFF
--- a/twitterscraper/query.py
+++ b/twitterscraper/query.py
@@ -8,6 +8,7 @@ from multiprocessing.pool import Pool
 
 from twitterscraper.tweet import Tweet
 from twitterscraper.ts_logger import logger
+import urllib
 
 HEADERS_LIST = [
     'Mozilla/5.0 (Windows; U; Windows NT 6.1; x64; fr; rv:1.9.2.13) Gecko/20101203 Firebird/3.6.13',
@@ -66,7 +67,7 @@ def query_single_page(url, html_response=True, retry=10, from_user=False):
             return [], None
 
         if not html_response:
-            return tweets, json_resp['min_position']
+            return tweets, urllib.parse.quote(json_resp['min_position'])
 
         if from_user:
             return tweets, tweets[-1].id


### PR DESCRIPTION
Fixed bug in query.py that kept queries in an endless loop that returned the same tweets repeatedly. This is a recent issue being reported by some users: #149 and #148. 

In query.py, inside the function "query_single_page" the answer returned by "json_resp['min_position']" needed to be wrapped by urllib.parse.quote in order to quote special characters appropriately encode non-ASCII text. More information about this urllib library can be found here: https://docs.python.org/dev/library/urllib.parse.html#urllib.parse.quote

Here is the old code:

`
        if not html_response:
            return tweets, json_resp['min_position']
`

Here is the fixed code:

`        if not html_response:
            return tweets, urllib.parse.quote(json_resp['min_position'])
`