### PR TITLE
It just seems like It is a typo (from issue 199)

### DIFF
--- a/twitterscraper/query.py
+++ b/twitterscraper/query.py
@@ -59,7 +59,7 @@ def query_single_page(query, lang, pos, retry=50, from_user=False):
     :return: The list of tweets, the pos argument for getting the next page.
     """
     url = get_query_url(query, lang, pos, from_user)
-    logger.info('Scraping tweets from {}', url)
+    logger.info('Scraping tweets from {}'.format(url))
 
     try:
         response = requests.get(url, headers=HEADER)


### PR DESCRIPTION
https://github.com/taspinar/twitterscraper/issues/199

Using previous version is solution of problem, is like because there is no that function before.

Fix it like this because of other " logger.info" usage.
