### PR TITLE
Adds 'images_urls' and 'has_video' attributes to tweets

### DIFF
--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -116,11 +116,11 @@ def main():
                         f = csv.writer(output, delimiter=";", quoting=csv.QUOTE_NONNUMERIC)
                         f.writerow(["username", "fullname","user_id", "tweet_id", "tweet_url", "timestamp","timestamp_epochs",
                                     "replies", "retweets", "likes", "is_retweet", "retweeter_username" , "retweeter_userid" ,
-                                    "retweet_id","text", "html"])
+                                    "retweet_id","text", "html", "images_urls", "has_video"])
                         for t in tweets:
                             f.writerow([t.username, t.fullname,t.user_id, t.tweet_id, t.tweet_url, t.timestamp, t.timestamp_epochs,
                                         t.replies, t.retweets, t.likes, t.is_retweet, t.retweeter_username , t.retweeter_userid ,
-                                        t.retweet_id, t.text, t.html])
+                                        t.retweet_id, t.text, t.html, t.images_urls, t.has_video])
                     else:
                         json.dump(tweets, output, cls=JSONEncoder)
             if args.profiles and tweets:

--- a/twitterscraper/tweet.py
+++ b/twitterscraper/tweet.py
@@ -7,7 +7,7 @@ from coala_utils.decorators import generate_ordering
 @generate_ordering('timestamp', 'id', 'text', 'user', 'replies', 'retweets', 'likes')
 class Tweet:
     def __init__(self, username, fullname, user_id, tweet_id, tweet_url, timestamp, timestamp_epochs, replies, retweets,
-                 likes, is_retweet, retweeter_username, retweeter_userid, retweet_id,text, html):
+                 likes, is_retweet, retweeter_username, retweeter_userid, retweet_id,text, html, images_urls, has_video):
         self.username = username.strip('\@')
         self.fullname = fullname
         self.user_id = user_id
@@ -24,6 +24,8 @@ class Tweet:
         self.retweet_id = retweet_id
         self.text = text
         self.html = html
+        self.images_urls = images_urls
+        self.has_video = has_video
 
     @classmethod
     def from_soup(cls, tweet):
@@ -57,9 +59,16 @@ class Tweet:
             'span', 'ProfileTweet-action--favorite u-hiddenVisually').find(
             'span', 'ProfileTweet-actionCount')['data-tweet-stat-count'] or '0')
         html = str(tweet.find('p', 'tweet-text')) or ""
-            
+
+        images_urls = [
+            div.find("img").attrs.get("src", '') for div
+            in tweet_div.findAll("div", "AdaptiveMedia-photoContainer")
+        ]
+
+        has_video = tweet_div.find("div", "PlayableMedia-players") is not None
+
         c = cls(username, fullname, user_id, tweet_id, tweet_url, timestamp, timestamp_epochs, replies, retweets, likes,
-                 is_retweet, retweeter_username, retweeter_userid, retweet_id,text, html)
+                 is_retweet, retweeter_username, retweeter_userid, retweet_id,text, html, images_urls, has_video)
         return c
 
     @classmethod


### PR DESCRIPTION
Hi! I made small modifications to be able to download the images coming with a tweet. I thought it might be useful. :)

By the way, it's related to #200.

Now, a Tweet object contains:

- an 'images_urls' attribute, which is a list containing the urls of the images of tweet;
- a 'has_video' attribute, which a boolean, set to True if the tweet has a video, false either.

It is currently not possible to get the video url, because it does not come with the tweet HTML (it seems to be added after loading with Javascript).

Edit: Videos are added by an obfuscated script, which uses an API requiring parameters which are very difficult to get (they're hidden in an unreadable bloat of JS). The URL of the API is something like `https://api.twitter.com/1.1/videos/tweet/config/XXX.json` (with XXX = the ID of the tweet), it requires an authorization header and some cookies.