### PR TITLE
Pretty printing

### DIFF
--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -7,6 +7,7 @@ import argparse
 import collections
 import datetime as dt
 from os.path import isfile
+from pprint import pprint
 from twitterscraper.query import query_tweets
 from twitterscraper.query import query_tweets_from_user
 from twitterscraper.query import query_user_info
@@ -107,7 +108,7 @@ def main():
                               poolsize = args.poolsize, lang = args.lang)
 
         if args.dump:
-            print(json.dumps(tweets, cls=JSONEncoder))
+            pprint([tweet.__dict__ for tweet in tweets])
         else:
             if tweets:
                 with open(args.output, "w", encoding="utf-8") as output:


### PR DESCRIPTION
Use `pprint.pprint` instead of basic `print` for well arranged dumped output.

The `loads`/`dumps` mechanism could be possibly rewritten, however, this way the `JSONEncoder` works very nice.

Looking forward for comments!