### PR TITLE
Force CSV quoting for all non-numeric values

### DIFF
--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -112,7 +112,7 @@ def main():
             if tweets:
                 with open(args.output, "w", encoding="utf-8") as output:
                     if args.csv:
-                        f = csv.writer(output, delimiter=";")
+                        f = csv.writer(output, delimiter=";", quoting=csv.QUOTE_NONNUMERIC)
                         f.writerow(["username", "fullname","user_id", "tweet_id", "tweet_url", "timestamp","timestamp_epochs",
                                     "replies", "retweets", "likes", "is_retweet", "retweeter_username" , "retweeter_userid" ,
                                     "retweet_id","text", "html"])


### PR DESCRIPTION
I used to get some invalid CSVs (hard to reproduce since `--user` option doesn't support time ranges). This explicit quoting strategy fixed that.

Looking forward for comments!