### PR TITLE
Use request json() method instead of manual json parsing.

### DIFF
--- a/twitterscraper/query.py
+++ b/twitterscraper/query.py
@@ -96,7 +96,7 @@ def query_single_page(query, lang, pos, retry=50, from_user=False, timeout=60):
         else:
             html = ''
             try:
-                json_resp = json.loads(response.text)
+                json_resp = response.json()
                 html = json_resp['items_html'] or ''
             except ValueError as e:
                 logger.exception('Failed to parse JSON "{}" while requesting "{}"'.format(e, url))


### PR DESCRIPTION
This fixes unexpected error caused by `json.loads` inability to parse non-json strings.

```ERROR: Failed to parse JSON "Expecting value: line 1 column 1 (char 0)" while requesting ...```