### PR TITLE
Add "mentions" and "is_mentions" attributes to Tweet model

### DIFF
--- a/twitterscraper/tweet.py
+++ b/twitterscraper/tweet.py
@@ -7,7 +7,7 @@ from coala_utils.decorators import generate_ordering
 @generate_ordering('timestamp', 'id', 'text', 'user', 'replies', 'retweets', 'likes')
 class Tweet:
     def __init__(self, username, fullname, user_id, tweet_id, tweet_url, timestamp, timestamp_epochs, replies, retweets,
-                 likes, is_retweet, retweeter_username, retweeter_userid, retweet_id,text, html):
+                 likes, is_retweet, retweeter_username, retweeter_userid, retweet_id, text, html, mentions):
         self.username = username.strip('\@')
         self.fullname = fullname
         self.user_id = user_id
@@ -24,6 +24,8 @@ class Tweet:
         self.retweet_id = retweet_id
         self.text = text
         self.html = html
+        self.mentions = mentions
+        self.is_mentions = 1 if mentions else 0
 
     @classmethod
     def from_soup(cls, tweet):
@@ -57,9 +59,11 @@ class Tweet:
             'span', 'ProfileTweet-action--favorite u-hiddenVisually').find(
             'span', 'ProfileTweet-actionCount')['data-tweet-stat-count'] or '0')
         html = str(tweet.find('p', 'tweet-text')) or ""
-            
+        mentions_str = tweet.find('div', 'tweet').get('data-mentions', '')
+        mentions = mentions_str.split(' ') if mentions_str else []
+
         c = cls(username, fullname, user_id, tweet_id, tweet_url, timestamp, timestamp_epochs, replies, retweets, likes,
-                 is_retweet, retweeter_username, retweeter_userid, retweet_id,text, html)
+                is_retweet, retweeter_username, retweeter_userid, retweet_id, text, html, mentions)
         return c
 
     @classmethod


### PR DESCRIPTION
Hi! I made small modifications to get infomation of mentions in tweets. I thought it might be useful:)

## problem

Now, tweets we can get by twitterscraper has **no mension information**, so we can't tell the difference between normal tweets and mension tweets(tweets with like "@foo" to reply to another user).

## modifications

By adding "is_mension" and "mension" attributes Tweet model(tweet.py), we will easily find if tweets are "normal" or "mention".

I mainly edited "Tweet" model in `tweet.py`.

* add "mentions" and "is_mentions" attributes.
  * Tweet.mentions: username(screen name) list
  * Tweet.is_mentions: If a tweet is a mention tweet, this param attr is True.

This new attributes is just for tell the difference between 2 type tweets(normal / mention), not for make tweets threads by using tweet-id... Though it's trivial functions, it's very simple and helpful to use twitterscraper.
