### PR TITLE
fix bug for --profiles

### DIFF
--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -124,7 +124,7 @@ def main():
                     else:
                         json.dump(tweets, output, cls=JSONEncoder)
             if args.profiles and tweets:
-                list_users = list(set([tweet.user for tweet in tweets]))
+                list_users = list(set([tweet.username for tweet in tweets]))
                 list_users_info = [query_user_info(elem) for elem in list_users]
                 filename = 'userprofiles_' + args.output
                 with open(filename, "w", encoding="utf-8") as output:


### PR DESCRIPTION
The commit "Adds is_retweet and retweeter related information " (1fe473b9528c46b1afbf73cd0d2e03c1d197c8a0) renamed the `Tweet` attribute `user` to `username`, however `main.py` was not updated accordingly. This leads to an error in line 127 of `main.py`. This PR simply changes the attribute used in line 127 of `main.py` from `user` to `username`.