### PR TITLE
Add deps required to build other deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.7-alpine
 COPY . /app
 WORKDIR /app
+RUN apk add build-base libxml2-dev libxslt-dev
 RUN python setup.py install
 CMD ["twitterscraper"]


### PR DESCRIPTION
This increases the size of the image quite a lot.

Alternatives welcomed. Would also be nice to pin the container version so that this doesn't become stale again, but I don't know if you want to do that.

We can pin by setting FROM to python:3.7-alpine3.10.