### PR TITLE
Option to disable proxying requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,7 @@ JSON right away. Twitterscraper takes several arguments:
    it will be overwritten. If this argument is not set (default) twitterscraper will
    exit with the warning that the output file already exists.
 
+-  ``-dp`` or ``--disableproxy``: With this argument, proxy servers are not used when scrapping tweets or user profiles from twitter.
 
 2.2.1 Examples of simple queries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/twitterscraper/main.py
+++ b/twitterscraper/main.py
@@ -91,6 +91,7 @@ def main():
         parser.add_argument("-p", "--poolsize", type=int, default=20, help="Specify the number of parallel process you want to run. \n"
                             "Default value is set to 20. \nYou can change this number if you have more computing power available. \n"
                             "Set to 1 if you dont want to run any parallel processes.", metavar='\b')
+        parser.add_argument("-dp", "--disableproxy", action="store_true", default=False, help="Set this flag if you want to disable use of proxy servers when scrapping tweets and user profiles. \n")
         args = parser.parse_args()
 
         if isfile(args.output) and not args.dump and not args.overwrite:
@@ -101,11 +102,11 @@ def main():
             args.begindate = dt.date(2006,3,1)
 
         if args.user:
-            tweets = query_tweets_from_user(user = args.query, limit = args.limit)
+            tweets = query_tweets_from_user(user = args.query, limit = args.limit, use_proxy = not args.disableproxy)
         else:
             tweets = query_tweets(query = args.query, limit = args.limit,
                               begindate = args.begindate, enddate = args.enddate,
-                              poolsize = args.poolsize, lang = args.lang)
+                              poolsize = args.poolsize, lang = args.lang, use_proxy = not args.disableproxy)
 
         if args.dump:
             pprint([tweet.__dict__ for tweet in tweets])
@@ -136,7 +137,7 @@ def main():
                         json.dump(tweets, output, cls=JSONEncoder)
             if args.profiles and tweets:
                 list_users = list(set([tweet.username for tweet in tweets]))
-                list_users_info = [query_user_info(elem) for elem in list_users]
+                list_users_info = [query_user_info(elem, not args.disableproxy) for elem in list_users]
                 filename = 'userprofiles_' + args.output
                 with open(filename, "w", encoding="utf-8") as output:
                     json.dump(list_users_info, output, cls=JSONEncoder)

--- a/twitterscraper/query.py
+++ b/twitterscraper/query.py
@@ -73,7 +73,7 @@ def linspace(start, stop, n):
 proxies = get_proxies()
 proxy_pool = cycle(proxies)
 
-def query_single_page(query, lang, pos, retry=50, from_user=False, timeout=60):
+def query_single_page(query, lang, pos, retry=50, from_user=False, timeout=60, use_proxy=True):
     """
     Returns tweets from the given URL.
 
@@ -87,9 +87,13 @@ def query_single_page(query, lang, pos, retry=50, from_user=False, timeout=60):
     logger.info('Scraping tweets from {}'.format(url))
 
     try:
-        proxy = next(proxy_pool)
-        logger.info('Using proxy {}'.format(proxy))
-        response = requests.get(url, headers=HEADER, proxies={"http": proxy}, timeout=timeout)
+        if use_proxy:
+            proxy = next(proxy_pool)
+            logger.info('Using proxy {}'.format(proxy))
+            response = requests.get(url, headers=HEADER, proxies={"http": proxy}, timeout=timeout)
+        else:
+            print('not using proxy')
+            response = requests.get(url, headers=HEADER, timeout=timeout)
         if pos is None:  # html response
             html = response.text or ''
             json_resp = None
@@ -117,7 +121,7 @@ def query_single_page(query, lang, pos, retry=50, from_user=False, timeout=60):
                 pass
             if retry > 0:
                 logger.info('Retrying... (Attempts left: {})'.format(retry))
-                return query_single_page(query, lang, pos, retry - 1, from_user)
+                return query_single_page(query, lang, pos, retry - 1, from_user, use_proxy=use_proxy)
             else:
                 return [], pos
 
@@ -142,13 +146,13 @@ def query_single_page(query, lang, pos, retry=50, from_user=False, timeout=60):
 
     if retry > 0:
         logger.info('Retrying... (Attempts left: {})'.format(retry))
-        return query_single_page(query, lang, pos, retry - 1)
+        return query_single_page(query, lang, pos, retry - 1, use_proxy=use_proxy)
 
     logger.error('Giving up.')
     return [], None
 
 
-def query_tweets_once_generator(query, limit=None, lang='', pos=None):
+def query_tweets_once_generator(query, limit=None, lang='', pos=None, use_proxy=True):
     """
     Queries twitter for all the tweets you want! It will load all pages it gets
     from twitter. However, twitter might out of a sudden stop serving new pages,
@@ -170,7 +174,7 @@ def query_tweets_once_generator(query, limit=None, lang='', pos=None):
     num_tweets = 0
     try:
         while True:
-            new_tweets, new_pos = query_single_page(query, lang, pos)
+            new_tweets, new_pos = query_single_page(query, lang, pos, use_proxy=use_proxy)
             if len(new_tweets) == 0:
                 logger.info('Got {} tweets for {}.'.format(
                     num_tweets, query))
@@ -208,7 +212,7 @@ def query_tweets_once(*args, **kwargs):
         return []
 
 
-def query_tweets(query, limit=None, begindate=dt.date(2006, 3, 21), enddate=dt.date.today(), poolsize=20, lang=''):
+def query_tweets(query, limit=None, begindate=dt.date(2006, 3, 21), enddate=dt.date.today(), poolsize=20, lang='', use_proxy=True):
     no_days = (enddate - begindate).days
     
     if(no_days < 0):
@@ -233,7 +237,7 @@ def query_tweets(query, limit=None, begindate=dt.date(2006, 3, 21), enddate=dt.d
         pool = Pool(poolsize)
         logger.info('queries: {}'.format(queries))
         try:
-            for new_tweets in pool.imap_unordered(partial(query_tweets_once, limit=limit_per_pool, lang=lang), queries):
+            for new_tweets in pool.imap_unordered(partial(query_tweets_once, limit=limit_per_pool, lang=lang, use_proxy=use_proxy), queries):
                 all_tweets.extend(new_tweets)
                 logger.info('Got {} tweets ({} new).'.format(
                     len(all_tweets), len(new_tweets)))
@@ -247,12 +251,12 @@ def query_tweets(query, limit=None, begindate=dt.date(2006, 3, 21), enddate=dt.d
     return all_tweets
 
 
-def query_tweets_from_user(user, limit=None):
+def query_tweets_from_user(user, limit=None, use_proxy=True):
     pos = None
     tweets = []
     try:
         while True:
-           new_tweets, pos = query_single_page(user, lang='', pos=pos, from_user=True)
+           new_tweets, pos = query_single_page(user, lang='', pos=pos, from_user=True, use_proxy=use_proxy)
            if len(new_tweets) == 0:
                logger.info("Got {} tweets from username {}".format(len(tweets), user))
                return tweets
@@ -274,7 +278,7 @@ def query_tweets_from_user(user, limit=None):
     return tweets
 
 
-def query_user_page(url, retry=10, timeout=60):
+def query_user_page(url, retry=10, timeout=60, use_proxy=True):
     """
     Returns the scraped user data from a twitter user page.
 
@@ -284,9 +288,12 @@ def query_user_page(url, retry=10, timeout=60):
     """
 
     try:
-        proxy = next(proxy_pool)
-        logger.info('Using proxy {}'.format(proxy))
-        response = requests.get(url, headers=HEADER, proxies={"http": proxy})
+        if use_proxy:
+            proxy = next(proxy_pool)
+            logger.info('Using proxy {}'.format(proxy))
+            response = requests.get(url, headers=HEADER, proxies={"http": proxy})
+        else:
+            response = requests.get(url, headers=HEADER)
         html = response.text or ''
 
         user_info = User.from_html(html)
@@ -307,13 +314,13 @@ def query_user_page(url, retry=10, timeout=60):
 
     if retry > 0:
         logger.info('Retrying... (Attempts left: {})'.format(retry))
-        return query_user_page(url, retry-1)
+        return query_user_page(url, retry-1, use_proxy)
 
     logger.error('Giving up.')
     return None
 
 
-def query_user_info(user):
+def query_user_info(user, use_proxy=True):
     """
     Returns the scraped user data from a twitter user page.
 
@@ -322,7 +329,7 @@ def query_user_info(user):
 
 
     try:
-        user_info = query_user_page(INIT_URL_USER.format(u=user))
+        user_info = query_user_page(INIT_URL_USER.format(u=user), use_proxy=use_proxy)
         if user_info:
             logger.info("Got user information from username {}".format(user))
             return user_info

--- a/twitterscraper/query.py
+++ b/twitterscraper/query.py
@@ -166,7 +166,7 @@ def query_tweets_once_generator(query, limit=None, lang='', pos=None):
                   ``limit`` number of items.
     """
     logger.info('Querying {}'.format(query))
-    query = query.replace(' ', '%20').replace('#', '%23').replace(':', '%3A')
+    query = query.replace(' ', '%20').replace('#', '%23').replace(':', '%3A').replace('&', '%26')
     num_tweets = 0
     try:
         while True:


### PR DESCRIPTION
Fixes #222.

Add a flag named `-dp` or `--disableproxy` to disable the use of proxy servers when scrapping tweets.