### PR TITLE
For developers comfort: Add `Dockerfile.dev` and VSCode extension "Remote Development" setting file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-existing-dockerfile
+{
+    "name": "twitterscraper",
+    "context": "..",
+    "dockerFile": "../Dockerfile.dev",
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/ash"
+    },
+    "extensions": [
+        "ms-python.python",
+        // add your favorite extensions
+    ]
+}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,19 @@
+FROM python:3.7-alpine
+
+COPY . /workspaces/twitterscraper
+WORKDIR /workspaces/twitterscraper
+
+RUN apk add --no-cache \
+    gcc \
+    libc-dev \
+    libxml2-dev \
+    libxslt-dev \
+    git
+
+# for NOT installing "twitterscraper" from PyPI
+RUN pip install -r requirements.txt
+
+# for importing editable `twitterscraper` anywhere
+ENV PYTHONPATH /workspaces/twitterscraper
+
+CMD ["/bin/ash"]

--- a/README.rst
+++ b/README.rst
@@ -315,3 +315,49 @@ After the file has been opened, it can easily be converted into a pandas DataFra
 
     import pandas as pd
     df = pd.read_json('tweets.json', encoding='utf-8')
+
+4. For Developers
+=================
+
+If you are Docker user, you can develop ``twitterscraper`` comfortably.
+
+4.1 For Developers using Docker
+-------------------------------
+
+In the container built by ``Dockerfile``, your edits are not reflected to ``import twitterscraper``
+because ``twitterscraper`` is installed from PyPI in this container.
+
+If you wanna develop ``twitterscraper`` by "try and error",
+you should build a container by ``Dockerfile.env``, not ``Dockerfile``.
+
+If you use ``Dockerfile.env``, your edits will be reflected immediately to ``import twitterscraper``
+because the container building by ``Dockerfile.env`` doesn't install ``twitterscraper`` from PyPI,
+In this container, your cloned ``twitterscraper``, not from PyPI, will be used when executing ``import twitterscraper``.
+(in ``Dockerfile.env``, your cloned ``twitterscraper`` is added to ``PYTHONPATH``).
+
+The procedure is as follows:
+
+::
+
+    $ git clone https://github.com/taspinar/twitterscraper.git
+    $ cd twitterscraper
+    $ docker build . -f Dockerfile.dev -t twitterscraper:dev
+    $ docker run -it --rm twitterscraper:dev /bin/ash
+    # into the container
+
+Now, you can import ``twitterscraper`` anywhere in Python files in the container.
+
+4.2 For Developers using Docker & Visual Studio Code
+----------------------------------------------------
+
+If you are Docker & Visual Studio Code(VSCode) user, you can conveniently
+develop ``twitterscraper`` by using VSCode's extension "**Remote Development**".
+The procedure is as follows:
+
+1. Install the extension "Remote Development".
+2. Add VSCode extensions to the setting file ``.devcontainer/devcontainer.json``.
+3. Press `cmd + shift + P`, enter & select ``Remote-Containers: Open Folder in Container...``
+4. Select the directory cloned by `git clone https://github.com/taspinar/twitterscraper.git`
+5. Stating to build. After building, you can now develop ``twitterscraper``!!
+
+In this procedure, ``Dockerfile.dev`` is used, so your edits are reflected immediately to ``import twitterscraper``.


### PR DESCRIPTION

I made this pull request for developer comfort.

## Current Problems

In existing `Dockerfile`, our edits are not reflected in `import twitterscraper` in Python files and difficult to experiment because `twitterscraper` is installed from PyPI. If developers wanna reflect their edits to `twitterscraper`, they have to edit `/usr/local/lib/python3.7/site-packages/twitterscraper`.

## Pull Request Contents

To overcome the above situation, I added and edited the followings:

* added
  * `Dockerfile.dev`
  * `.devcontainer/devcontainer.json`
* edited
  * `README.rst`

### `Dockerfile.dev`

`Dockerfile.dev` enables developers to use editable `twitterscraper`. When executing `import twitterscraper`, they can import cloned `twitterscraper`, not from PyPI, because `twitterscraper` is added to `PYTHONPATH` in `Dockerfile.dev`. Naturally `git` is also installed unlike existing `Dockerfile`.

The container build by `Dockerfile.dev` will make developing more comfortable.

### `.devcontainer/devcontainer.json`

This file is for Visual Studio Code(VSCode) users. As you know, VSCode offers a very convenient extension "Remote Development". By adding this extension's setting file, I make developers start developing easily on VSCode.

In this setting file `Dockerfile.dev` is used, so developers use editable `twitterscraper`, too.

### `README.rst`

Due to adding the above file, I added item `For Developers` to `README.rst`.
However, my English would be awful, so you can throw away this changes.

I hope my changes will make `twitterscraper` developers comfortable.
