### PR TITLE
Use seconds in date queries, add json dump

### DIFF
--- a/twitterscraper/query.py
+++ b/twitterscraper/query.py
@@ -5,6 +5,7 @@ import requests
 import urllib
 import random
 import datetime as dt
+import time
 
 from functools import partial
 from billiard.pool import Pool
@@ -208,24 +209,24 @@ def query_tweets_once(*args, **kwargs):
         return []
 
 
-def query_tweets(query, limit=None, begindate=dt.date(2006, 3, 21), enddate=dt.date.today(), poolsize=20, lang=''):
-    no_days = (enddate - begindate).days
+def query_tweets(query, limit=None, begindate=dt.date(2006, 3, 21), enddate=dt.datetime.now(), poolsize=20, lang=''):
+    no_secs = (enddate - begindate).seconds
     
-    if(no_days < 0):
+    if(no_secs < 0):
         sys.exit('Begin date must occur before end date.')
-    
-    if poolsize > no_days:
+
+    if poolsize > no_secs:
         # Since we are assigning each pool a range of dates to query,
 		# the number of pools should not exceed the number of dates.
-        poolsize = no_days
-    dateranges = [begindate + dt.timedelta(days=elem) for elem in linspace(0, no_days, poolsize+1)]
+        poolsize = no_secs
+    dateranges = [begindate + dt.timedelta(seconds=elem) for elem in linspace(0, no_secs, poolsize+1)]
 
     if limit and poolsize:
         limit_per_pool = (limit // poolsize)+1
     else:
         limit_per_pool = None
 
-    queries = ['{} since:{} until:{}'.format(query, since, until)
+    queries = ['{} since_time:{} until_time:{}'.format(query, int(time.mktime(since.timetuple())), int(time.mktime(until.timetuple())))
                for since, until in zip(dateranges[:-1], dateranges[1:])]
 
     all_tweets = []


### PR DESCRIPTION
Hello guys. Sorry, I'm new to python, maybe something is done very badly. I've tried to follow original code as much as I can.

Twitter supports date queries using since_time and until_time, so I've updated package a little bit to use it. So now you can do query like `twitterscraper "love OR day" --limit 1000 -bd "2020-02-01 21:40:50" -ed "2020-02-01 21:40:55"`.

I've also added -dj or --dump-json flag, to dump output directly, but in json, so I can use this package as cli utility from another program.