### PR TITLE
Fixing query.py

### DIFF
--- a/twitterscraper/query.py
+++ b/twitterscraper/query.py
@@ -26,7 +26,7 @@ HEADERS_LIST = [
     'Mozilla/5.0 (Windows NT 5.2; RW; rv:7.0a1) Gecko/20091211 SeaMonkey/9.23a1pre'
 ]
 
-HEADER = {'User-Agent': random.choice(HEADERS_LIST)}
+HEADER = {'User-Agent': random.choice(HEADERS_LIST), 'X-Requested-With': 'XMLHttpRequest'}
 logger.info(HEADER)
 
 INIT_URL = 'https://twitter.com/search?f=tweets&vertical=default&q={q}&l={lang}'


### PR DESCRIPTION
There was a bug in query.py https://github.com/taspinar/twitterscraper/issues/296 that cause query_tweets() to fetch 0 tweets. The solution was in one of the answers in the threads (change of HEADERS value in query.py). I though someone should apply this to the actual repo as this package is actually amazing and such a minor problem takes away its usefulness

